### PR TITLE
small tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#### OneSignal Ionic Example
+#### OneSignal Ionic v1 Example
 
-- To build the example first run `ionic platform add android` andr/or `ionic platform add ios`.
-- Next run `cordova plugin add onesignal-cordova-plugin`
-- Open `www\js\app.js` and update "b2f7f966-d8cc-11e4-bed1-df8f05be55ba" with your OneSignal App Id.
+- To build the example first run `ionic cordova platform add android` andr/or `ionic cordova platform add ios`.
+- Next run `ionic cordova plugin add onesignal-cordova-plugin`
+- Open `www/js/app.js` and update "b2f7f966-d8cc-11e4-bed1-df8f05be55ba" with your OneSignal App Id.
 - Build then run the app on your device.


### PR DESCRIPTION
AngularJS based Ionic 1.x is known as "Ionic v1"
Current Ionic CLI uses `ionic cordova platform` instead of `ionic platform`
Current Ionic CLI also handles installing plugins with `ionic cordova`